### PR TITLE
Fix bug in getX(idx) method generated for repeated field access.

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,7 @@
 The MIT License
 
 Copyright (c) 2011, 2012 Iván -DrSlump- Montes
+Copyright (c) 2015 Google, Inc.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/library/DrSlump/Protobuf/Compiler/templates/php-message.php
+++ b/library/DrSlump/Protobuf/Compiler/templates/php-message.php
@@ -135,7 +135,7 @@ namespace <?php echo $this->ns($namespace)?> {
          */
         public function get<?php echo $Name?>($idx = null)
         {
-            if (NULL == $idx || !array_key_exists($idx, $this-><?php echo $name?>)) {
+            if (NULL === $idx || !array_key_exists($idx, $this-><?php echo $name?>)) {
                 return  \PhpOption\None::create();
             }
 


### PR DESCRIPTION
In "getX(idx)" method generated for repeated field access, NULL check for $idx should use ===, not ==.  Otherwise, $idx of 0 will fail.

Note: I'm pretty new to PHP programming so apologies if I've gotten the details wrong here.