### PR TITLE
Fix lazy repeater

### DIFF
--- a/library/DrSlump/Protobuf/Compiler/templates/php-message.php
+++ b/library/DrSlump/Protobuf/Compiler/templates/php-message.php
@@ -163,7 +163,6 @@ namespace <?php echo $this->ns($namespace)?> {
         }
 
         /**
-         * @deprecated
          * Set "<?php echo $name?>" list
          * @param <?php echo $this->doctype($f)?>[]|\Traversable $value
          */

--- a/library/DrSlump/Protobuf/Compiler/templates/php-message.php
+++ b/library/DrSlump/Protobuf/Compiler/templates/php-message.php
@@ -153,14 +153,24 @@ namespace <?php echo $this->ns($namespace)?> {
         }
 
         /**
+         * @deprecated Use set<?php echo $Name?>List($value) instead
          * Set "<?php echo $name?>" value
-         *
          * @param <?php echo $this->doctype($f)?>[] $value
          */
         public function set<?php echo $Name?>($value)
         {
             return $this-><?php echo $name?> = $value;
         }
+
+        /**
+         * @deprecated
+         * Set "<?php echo $name?>" list
+         * @param <?php echo $this->doctype($f)?>[]|\Traversable $value
+         */
+         public function set<?php echo $Name?>List($value)
+         {
+             return $this-><?php echo $name?> = $value;
+         }
 
         /**
          * Add a new element to "<?php echo $name?>"

--- a/library/DrSlump/Protobuf/LazyRepeat.php
+++ b/library/DrSlump/Protobuf/LazyRepeat.php
@@ -2,8 +2,6 @@
 
 namespace DrSlump\Protobuf;
 
-use DrSlump\Protobuf;
-
 class LazyRepeat extends LazyValue implements \Iterator, \Countable, \ArrayAccess 
 {
     protected $_ofs = 0;


### PR DESCRIPTION
This commit is forked off tag 0.6.5 - the latest tag to support php 5.3

Had to remove the use statement in LazyRepeat to get Message::parse() with PhpArray codec working.