### PR TITLE
Extension template generated invalid output.

### DIFF
--- a/library/DrSlump/Protobuf/Compiler/templates/php-extension.php
+++ b/library/DrSlump/Protobuf/Compiler/templates/php-extension.php
@@ -6,24 +6,24 @@
         $data      - An array of google.protobuf.FieldDescriptorProto objects
 
     */ ?>
- 
+
+namespace {
 <?php foreach ($data as $f): ?>
 
 \<?php echo $this->ns($f->extendee)?>::extension(function(){
-    
-    // <?php echo $this->rule($f)?> <?php echo $this->type($f)?> <?php echo $f->name?> = <?php echo $f->number?> 
+    // <?php echo $this->rule($f)?> <?php echo $this->type($f)?> <?php echo $f->name?> = <?php echo $f->number?>
+
     $f = new \DrSlump\Protobuf\Field();
     $f->number = <?php echo $f->number?>;
     $f->name   = "<?php echo $f->name?>";
-    $f->rule   = \DrSlump\Protobuf\Protobuf::RULE_<?php echo $this->rule($f)?>;
-    $f->type   = \DrSlump\Protobuf\Protobuf::TYPE_<?php echo $this->type($f)?>;
+    $f->rule   = \DrSlump\Protobuf\Protobuf::RULE_<?php echo strtoupper($this->rule($f))?>;
+    $f->type   = \DrSlump\Protobuf\Protobuf::TYPE_<?php echo strtoupper($this->type($f))?>;
     <?php if ($f->hasTypeName()):
         $ref = $f->type_name;
         if (substr($ref, 0, 1) !== '.') {
             throw new \RuntimeException("Only fully qualified names are supported but found '$ref' at $ns");
         }
-    ?>
-    $f->reference = '\<?php echo $this->ns($f->reference)?>';
+    ?>$f->reference = '\<?php echo $this->ns($ref)?>';
     <?php endif ?>
     <?php
     if ($f->hasDefaultValue()):
@@ -59,3 +59,4 @@
 });
 
 <?php endforeach ?>
+}


### PR DESCRIPTION
Added global namespace definition surrounding the extension definitions.
Fixed outputing the reference to the message describing the extension. This used to be `$f->reference`, but should have been `$ref`.
Fixed partial lowercase constants for field type and rule.