### PR TITLE
Set packed flag in field descriptor to support packed data

### DIFF
--- a/library/DrSlump/Protobuf/Compiler/templates/php-message.php
+++ b/library/DrSlump/Protobuf/Compiler/templates/php-message.php
@@ -49,6 +49,7 @@ namespace <?php echo $this->ns($namespace)?> {
             $f->name   = "<?php echo $this->fieldname($f)?>";
             $f->rule   = \DrSlump\Protobuf\Protobuf::RULE_<?php echo strtoupper($this->rule($f))?>;
             $f->type   = \DrSlump\Protobuf\Protobuf::TYPE_<?php echo strtoupper($this->type($f))?>;
+            $f->packed = <?php echo (($f->hasOptions() && $f->getOptions()->getPacked()) ? 'true' : 'false');?>;
             <?php if (!empty($f->type_name)):
                 $ref = $f->type_name;
                 if (substr($ref, 0, 1) !== '.') {


### PR DESCRIPTION
The library supports packed data. But unfortunately the packed options is not transferred into the field descriptor within the default template. This PR fixes this.