### PR TITLE
Don't send defaults over the wire

### DIFF
--- a/library/DrSlump/Protobuf/Codec/Binary/Native.php
+++ b/library/DrSlump/Protobuf/Codec/Binary/Native.php
@@ -348,8 +348,15 @@ class Native extends Protobuf\CodecAbstract
                 );
             }
 
-            // Skip unknown fields
-            if ($empty && !$field->hasDefault()) {
+            // skip not set values
+            if ($empty) {
+                continue;
+            }
+            
+            $value = $message[$tag];
+            
+            // don't send nulls or defaults over the wire
+            if (NULL === $value || ($field->hasDefault() && $field->getDefault() === $value)) {
                 continue;
             }
 
@@ -358,12 +365,6 @@ class Native extends Protobuf\CodecAbstract
 
             // Compute key with tag number and wire type
             $key = $tag << 3 | $wire;
-
-            $value = $message[$tag];
-
-            if (NULL === $value) {
-                continue;
-            }
 
             if ($field->isRepeated()) {
 

--- a/library/DrSlump/Protobuf/Codec/PhpArray.php
+++ b/library/DrSlump/Protobuf/Codec/PhpArray.php
@@ -59,18 +59,21 @@ class PhpArray extends Protobuf\CodecAbstract
                     'Message ' . get_class($message) . '\'s field tag ' . $tag . '(' . $field->getName() . ') is required but has no value'
                 );
             }
+            
+            // skip not set values
+            if ($empty) {
+                continue;
+            }
 
-            if ($empty && !$field->hasDefault()) {
+            $v = $message[$tag];
+
+            // don't send nulls or defaults over the wire
+            if (NULL === $v || ($field->hasDefault() && $field->getDefault() === $v)) {
                 continue;
             }
 
             $key = $useTagNumber ? $field->getNumber() : $field->getName();
-            $v = $message[$tag];
-
-            if (NULL === $v) {
-                continue;
-            }
-
+            
             if ($field->isRepeated()) {
                 // Make sure the value is iterable
                 if (!is_array($v) && !($v instanceof \Traversable)) {

--- a/library/DrSlump/Protobuf/Codec/TextFormat.php
+++ b/library/DrSlump/Protobuf/Codec/TextFormat.php
@@ -50,17 +50,20 @@ class TextFormat extends Protobuf\CodecAbstract
                     'Message ' . $descriptor->getName() . '\'s field tag ' . $tag . '(' . $field->getName() . ') is required but has no value'
                 );
             }
+            
+            // skip not set values
+            if ($empty) {
+                continue;
+            }
 
-            if ($empty && !$field->hasDefault()) {
+            $value = $message[$tag];
+
+            // don't send nulls or defaults over the wire
+            if (NULL === $value || ($field->hasDefault() && $field->getDefault() === $value)) {
                 continue;
             }
 
             $name = $field->getName();
-            $value = $message[$tag];
-
-            if ($value === NULL) {
-                continue;
-            }
 
             if ($field->isRepeated()) {
                 foreach ($value as $val) {


### PR DESCRIPTION
As described here: https://developers.google.com/protocol-buffers/docs/proto#updating "Changing a default value is generally OK, as long as you remember that default values are never sent over the wire".
I changed the codec implementations to also check for default values and don't send them.
The current implementation sends the default value over the wire also if this field was never set. That is not expected at all. 
Reason:
The magic `__get` is checking for defaults and initializes this field to the default. This also happens when the encoder accesses this field. So also if you have not set any value for that optional field the default is send over the wire. 